### PR TITLE
android:name set in manifest to the App class

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:name=".App">
         <activity android:name=".MainActivity"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>

--- a/app/src/main/java/com/lambda_labs/community_calendar/App.kt
+++ b/app/src/main/java/com/lambda_labs/community_calendar/App.kt
@@ -4,8 +4,6 @@ import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 
-// TODO: Add this App class to manifest, resolve how to handle expired tokens
-
 class App: Application() {
     companion object{
         const val TOKEN_KEY = "token_key"

--- a/app/src/main/java/com/lambda_labs/community_calendar/LoginFragment.kt
+++ b/app/src/main/java/com/lambda_labs/community_calendar/LoginFragment.kt
@@ -44,7 +44,7 @@ class LoginFragment : Fragment() {
                     //App.sharedPrefs.edit().putString(credentials.accessToken, App.TOKEN_KEY).apply()
                     App.token = credentials.accessToken
 
-                    mainActivity.apply {
+                    mainActivity.runOnUiThread {
                         val item = mainActivity.bottom_navigation.menu.findItem(R.id.loginFragment)
                         item.title = getString(R.string.profile)
                     }
@@ -72,7 +72,7 @@ class LoginFragment : Fragment() {
 
                         println("logged out")
 
-                        mainActivity.apply {
+                        mainActivity.runOnUiThread {
                             val item =
                                 mainActivity.bottom_navigation.menu.findItem(R.id.loginFragment)
                             item.title = getString(R.string.login)


### PR DESCRIPTION
Fixes #
lateinit shared preferences is now initialized with android:name being set in manifest
