### PR TITLE
Improve display of the filter fragment over the search fragment

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,18 +3,20 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.lambda_labs.community_calendar">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
-        tools:ignore="GoogleAppIndexingWarning"
+        android:name=".App"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:name=".App">
-        <activity android:name=".view.MainActivity"
+        tools:ignore="GoogleAppIndexingWarning">
+        <activity
+            android:name=".view.MainActivity"
             android:theme="@style/AppTheme.NoActionBar"
             android:windowSoftInputMode="adjustPan">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:theme="@style/AppTheme"
         android:name=".App">
         <activity android:name=".view.MainActivity"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/lambda_labs/community_calendar/view/FilterFragment.kt
+++ b/app/src/main/java/com/lambda_labs/community_calendar/view/FilterFragment.kt
@@ -1,4 +1,4 @@
-package com.lambda_labs.community_calendar
+package com.lambda_labs.community_calendar.view
 
 import android.os.Bundle
 import android.util.DisplayMetrics
@@ -9,6 +9,7 @@ import android.widget.ArrayAdapter
 import androidx.fragment.app.Fragment
 import androidx.navigation.Navigation
 import com.google.android.material.chip.Chip
+import com.lambda_labs.community_calendar.R
 import com.lambda_labs.community_calendar.util.DatePickerFragment
 import com.lambda_labs.community_calendar.util.ViewUtil
 import com.lambda_labs.community_calendar.util.getSearchDate
@@ -27,6 +28,11 @@ class FilterFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        // Enable touch event on this fragment in order to prevent views beneath from responding
+        view.setOnTouchListener { v, event ->
+            return@setOnTouchListener true
+        }
 
         image_view_fragment_filter_cancel.setOnClickListener {
             Navigation.findNavController(it).popBackStack()

--- a/app/src/main/java/com/lambda_labs/community_calendar/view/FilterFragment.kt
+++ b/app/src/main/java/com/lambda_labs/community_calendar/view/FilterFragment.kt
@@ -10,10 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.Navigation
 import com.google.android.material.chip.Chip
 import com.lambda_labs.community_calendar.R
-import com.lambda_labs.community_calendar.util.DatePickerFragment
-import com.lambda_labs.community_calendar.util.ViewUtil
-import com.lambda_labs.community_calendar.util.getSearchDate
-import com.lambda_labs.community_calendar.util.getToday
+import com.lambda_labs.community_calendar.util.*
 import kotlinx.android.synthetic.main.fragment_filter.*
 
 
@@ -35,6 +32,7 @@ class FilterFragment : Fragment() {
         }
 
         image_view_fragment_filter_cancel.setOnClickListener {
+            hideKeyboard(context as MainActivity)
             Navigation.findNavController(it).popBackStack()
         }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
-    android:id="@+id/c_layout"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/c_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".view.MainActivity">
@@ -16,26 +16,25 @@
         android:background="@drawable/rectangle"
         android:hint="@string/search_hint"
         app:iconifiedByDefault="false"
-        app:queryBackground="@android:color/transparent"
-        app:queryHint="@string/search_hint"
-        app:searchHintIcon="@null"
-        app:searchIcon="@null"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/nav_host_fragment"/>
+        app:queryBackground="@android:color/transparent"
+        app:queryHint="@string/search_hint"
+        app:searchHintIcon="@null"
+        app:searchIcon="@null" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_cancel"
-        android:visibility="gone"
         style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:fontFamily="@font/poppins_regular"
         android:text="Cancel"
-        android:textSize="14sp"
         android:textAllCaps="false"
         android:textColor="#66000000"
+        android:textSize="14sp"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@id/search_bar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toRightOf="@id/search_bar"
@@ -50,7 +49,7 @@
         app:layout_constraintBottom_toTopOf="@id/bottom_navigation"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/search_bar"
+        app:layout_constraintTop_toTopOf="parent"
         app:navGraph="@navigation/nav_graph" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
@@ -59,9 +58,9 @@
         android:layout_height="wrap_content"
         android:background="@android:color/white"
         app:itemBackground="@android:color/white"
-        app:labelVisibilityMode="labeled"
         app:itemIconTint="@drawable/bottom_nav_colors"
         app:itemTextColor="@drawable/bottom_nav_colors"
+        app:labelVisibilityMode="labeled"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_filter.xml
+++ b/app/src/main/res/layout/fragment_filter.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     app:cardCornerRadius="16dp">
@@ -46,127 +48,17 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-            android:id="@+id/text_view_fragment_filter_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="22dp"
-            android:fontFamily="@font/poppins_semi_bold"
-            android:text="@string/filter_text_view_title"
-            android:textColor="#000000"
-            android:textSize="24sp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/divider_view_fragment_filter_divider" />
-
-        <TextView
-            android:id="@+id/text_view_fragment_filter_location"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="20dp"
-            android:fontFamily="@font/poppins_regular"
-            android:text="@string/filter_text_view_location"
-            android:textColor="#000000"
-            android:textSize="14sp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/text_view_fragment_filter_title" />
-
-        <Spinner
-            android:id="@+id/spinner_fragment_filter_location"
-            style="@android:style/Widget.Material.Spinner.Underlined"
-            android:layout_width="189dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="14dp"
-            android:layout_marginEnd="16dp"
-            android:backgroundTint="#C4C4C4"
-            android:fontFamily="@font/poppins_regular"
-            android:spinnerMode="dropdown"
-            android:textAlignment="center"
-            android:textColor="#000000"
-            android:textSize="13sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/text_view_fragment_filter_title" />
-
-        <TextView
-            android:id="@+id/text_view_fragment_filter_zip_code"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="17dp"
-            android:fontFamily="@font/poppins_regular"
-            android:text="@string/filter_text_view_zip_code"
-            android:textColor="#000000"
-            android:textSize="14sp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/text_view_fragment_filter_location" />
-
-        <EditText
-            android:id="@+id/edit_text_fragment_filter_zip_code"
-            android:layout_width="189dp"
-            android:layout_height="40dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="16dp"
-            android:backgroundTint="#C4C4C4"
-            android:fontFamily="@font/poppins_regular"
-            android:gravity="center"
-            android:hint="@string/filter_edit_text_zip_code_hint"
-            android:inputType="number"
-            android:textColor="#000000"
-            android:textSize="13sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/spinner_fragment_filter_location" />
-
-        <TextView
-            android:id="@+id/text_view_fragment_filter_date"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="17dp"
-            android:fontFamily="@font/poppins_regular"
-            android:text="@string/filter_text_view_date"
-            android:textColor="#000000"
-            android:textSize="14sp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/text_view_fragment_filter_zip_code" />
-
-        <FrameLayout
-            android:layout_width="189dp"
-            android:layout_height="24dp"
-            android:layout_marginTop="3dp"
-            android:layout_marginEnd="16dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/edit_text_fragment_filter_zip_code">
-
-            <TextView
-                android:id="@+id/text_view_fragment_filter_date_shown"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:fontFamily="@font/poppins_regular"
-                android:textAlignment="center"
-                android:textColor="#000000"
-                android:textSize="13sp" />
-
-            <ImageView
-                android:id="@+id/image_view_fragment_filter_date"
-                style="@android:style/Widget.Material.Spinner.Underlined"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:backgroundTint="#C4C4C4" />
-
-        </FrameLayout>
-
-        <TextView
             android:id="@+id/text_view_fragment_filter_tags"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="17dp"
+            android:layout_marginTop="16dp"
             android:fontFamily="@font/poppins_regular"
             android:text="@string/filter_text_view_tags"
             android:textColor="#000000"
             android:textSize="14sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/text_view_fragment_filter_date" />
+            app:layout_constraintTop_toBottomOf="@+id/divider_view_fragment_filter_divider" />
 
         <androidx.appcompat.widget.SearchView
             android:id="@+id/search_bar_fragment_filter"
@@ -190,7 +82,7 @@
             android:layout_width="match_parent"
             android:layout_height="80dp"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="6dp"
+            android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/search_bar_fragment_filter"
@@ -244,7 +136,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="6dp"
+            android:layout_marginTop="16dp"
             android:fontFamily="@font/poppins_regular"
             android:text="@string/filter_text_view_suggested_tags"
             android:textColor="#000000"
@@ -360,6 +252,103 @@
 
         </ScrollView>
 
+        <TextView
+            android:id="@+id/text_view_fragment_filter_location"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:fontFamily="@font/poppins_regular"
+            android:text="@string/filter_text_view_location"
+            android:textColor="#000000"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/scroll_view_fragment_filter_suggested" />
+
+        <Spinner
+            android:id="@+id/spinner_fragment_filter_location"
+            style="@android:style/Widget.Material.Spinner.Underlined"
+            android:layout_width="189dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="16dp"
+            android:backgroundTint="#C4C4C4"
+            android:fontFamily="@font/poppins_regular"
+            android:spinnerMode="dropdown"
+            android:textAlignment="center"
+            android:textColor="#000000"
+            android:textSize="13sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/scroll_view_fragment_filter_suggested" />
+
+        <TextView
+            android:id="@+id/text_view_fragment_filter_zip_code"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="17dp"
+            android:fontFamily="@font/poppins_regular"
+            android:text="@string/filter_text_view_zip_code"
+            android:textColor="#000000"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_fragment_filter_location" />
+
+        <EditText
+            android:id="@+id/edit_text_fragment_filter_zip_code"
+            android:layout_width="189dp"
+            android:layout_height="40dp"
+
+            android:layout_marginEnd="16dp"
+            android:backgroundTint="#C4C4C4"
+            android:fontFamily="@font/poppins_regular"
+            android:gravity="center"
+            android:hint="@string/filter_edit_text_zip_code_hint"
+            android:inputType="number"
+            android:textColor="#000000"
+            android:textSize="13sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/spinner_fragment_filter_location" />
+
+        <TextView
+            android:id="@+id/text_view_fragment_filter_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="17dp"
+            android:fontFamily="@font/poppins_regular"
+            android:text="@string/filter_text_view_date"
+            android:textColor="#000000"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_fragment_filter_zip_code" />
+
+        <FrameLayout
+            android:layout_width="189dp"
+            android:layout_height="24dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/edit_text_fragment_filter_zip_code">
+
+            <TextView
+                android:id="@+id/text_view_fragment_filter_date_shown"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fontFamily="@font/poppins_regular"
+                android:textAlignment="center"
+                android:textColor="#000000"
+                android:textSize="13sp" />
+
+            <ImageView
+                android:id="@+id/image_view_fragment_filter_date"
+                style="@android:style/Widget.Material.Spinner.Underlined"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:backgroundTint="#C4C4C4" />
+
+        </FrameLayout>
+
         <Button
             android:id="@+id/button_fragment_filter_apply"
             android:layout_width="match_parent"
@@ -374,21 +363,6 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
-
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guideline"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layout_constraintGuide_begin="161dp" />
-
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guideline2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            app:layout_constraintGuide_begin="205dp" />
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:paddingTop="50dp"
     tools:context=".view.HomeFragment">
 
     <com.google.android.material.textview.MaterialTextView
@@ -193,12 +195,12 @@
         android:id="@+id/txt_no_events"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="invisible"
         android:fontFamily="@font/poppins_light"
-        android:textColor="@android:color/black"
-        app:layout_constraintTop_toTopOf="@id/main_event_recycler"
         android:textAlignment="center"
-        android:textSize="18sp"/>
+        android:textColor="@android:color/black"
+        android:textSize="18sp"
+        android:visibility="invisible"
+        app:layout_constraintTop_toTopOf="@id/main_event_recycler" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:paddingTop="50dp"
     tools:context=".view.LoginFragment">
 
     <!-- TODO: Update blank fragment layout -->
     <TextView
+        android:id="@+id/blank_logout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:fontFamily="@font/poppins_black"
         android:padding="60dp"
-        android:id="@+id/blank_logout"
-        android:text="@string/logout"
-        android:fontFamily="@font/poppins_black" />
+        android:text="@string/logout" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,57 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:paddingTop="50dp"
     tools:context=".view.SearchFragment">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_filters"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-        android:text="@string/filters"
-        android:textColor="#80000000"
         android:fontFamily="@font/poppins_light"
-        android:textAllCaps="false"
+        android:text="@string/filters"
         android:textAlignment="center"
+        android:textAllCaps="false"
+        android:textColor="#80000000"
         app:cornerRadius="18dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <HorizontalScrollView
         android:id="@+id/chips"
-        android:visibility="gone"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
+        android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@id/btn_filters">
 
         <com.google.android.material.chip.ChipGroup
             android:id="@+id/chip_group_search"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:singleLine="true">
-        </com.google.android.material.chip.ChipGroup>
+            app:singleLine="true"/>
+
     </HorizontalScrollView>
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_nearby"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginTop="16dp"
         style="@style/SearchPageItems"
-        app:icon="@drawable/nearby"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
         android:text="@string/nearby"
+        app:icon="@drawable/nearby"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/chips"
-        />
+        app:layout_constraintTop_toBottomOf="@id/chips" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/txt_recent_searches"
@@ -60,11 +61,11 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
         android:fontFamily="@font/poppins_medium"
-        android:textSize="10sp"
         android:text="@string/recent_searches"
+        android:textSize="10sp"
+        app:layout_constraintBottom_toTopOf="@id/searches_recycler"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/btn_nearby"
-        app:layout_constraintBottom_toTopOf="@id/searches_recycler"/>
+        app:layout_constraintTop_toBottomOf="@id/btn_nearby" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/searches_recycler"
@@ -73,9 +74,9 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
-        tools:listitem="@layout/searches_recycler_item"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/txt_recent_searches"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        tools:listitem="@layout/searches_recycler_item" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -38,7 +38,7 @@
 
     <fragment
         android:id="@+id/filterFragment"
-        android:name="com.lambda_labs.community_calendar.FilterFragment"
+        android:name="com.lambda_labs.community_calendar.view.FilterFragment"
         android:label="fragment_filter"
         tools:layout="@layout/fragment_filter" />
 


### PR DESCRIPTION
# Description
Move FilterFragment into the view package
Decouple SearchView from fragment to allow filling to the top
Put padding on top of Home/Search fragments to leave room for Search
Enable touch event on the Filter fragment to maintain focus

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Change Status
- [X] Complete, tested, ready to review and merge

# Checklist
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] There are no merge conflicts
